### PR TITLE
LDEV-6158 fix jakarta/javax bytecode binding in Form extension

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,24 @@
 name: Java CI Combined
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      lucee-versions:
+        description: 'JSON array of Lucee versions to test'
+        default: '["7.0/snapshot/light","7.0/stable/light","6.2/snapshot/light","6.2/stable/light"]'
+      dry-run:
+        description: 'Dry run - skip deploy to Maven'
+        type: boolean
+        default: false
 
 jobs:
   setup:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.extract-version.outputs.VERSION }}
+      lucee-matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -29,7 +41,17 @@ jobs:
         id: extract-version
         run: |
           VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo "::set-output name=VERSION::$VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Set Lucee test matrix
+        id: set-matrix
+        run: |
+          DEFAULT='["7.0/snapshot/light","7.0/stable/light","6.2/snapshot/light","6.2/stable/light"]'
+          MATRIX="${{ inputs.lucee-versions || '' }}"
+          if [ -z "$MATRIX" ]; then
+            MATRIX="$DEFAULT"
+          fi
+          echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
       - name: Cache Lucee files
         uses: actions/cache@v4
@@ -43,14 +65,9 @@ jobs:
         env:
           GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
 
-  build-and-test:
+  build:
     runs-on: ubuntu-latest
     needs: setup
-    env:
-      LUCEE_TEST_VERSIONS_JAKARTA: ${{ vars.LUCEE_TEST_VERSIONS_JAKARTA }}
-    strategy:
-      matrix:
-        lucee: ${{ fromJSON(vars.LUCEE_TEST_VERSIONS_JAKARTA) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -60,6 +77,14 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
       - name: Build and Install with Maven
         run: |
           echo "------- Maven Install -------";
@@ -68,8 +93,25 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: form-lex-${{ matrix.lucee.version }}
+          name: form-lex
           path: target/*.lex
+
+  test:
+    runs-on: ubuntu-latest
+    needs: [setup, build]
+    strategy:
+      fail-fast: false
+      matrix:
+        lucee: ${{ fromJSON(needs.setup.outputs.lucee-matrix) }}
+        java: [ 11, 21 ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: form-lex
+          path: target
 
       - name: Checkout Lucee
         uses: actions/checkout@v4
@@ -77,22 +119,29 @@ jobs:
           repository: lucee/lucee
           path: lucee
 
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'adopt'
+
       - name: Run Lucee Test Suite
         uses: lucee/script-runner@main
         with:
           webroot: ${{ github.workspace }}/lucee/test
           execute: /bootstrap-tests.cfm
-          luceeVersion: ${{ matrix.lucee.version }}
-          luceeVersionQuery: ${{ matrix.lucee.query }}
+          luceeVersion: ${{ matrix.lucee }}
           extensionDir: ${{ github.workspace }}/target
         env:
           testLabels: form
           testAdditional: ${{ github.workspace }}/tests
+          LUCEE_LOGGING_FORCE_APPENDER: console
+          LUCEE_LOGGING_FORCE_LEVEL: INFO
 
   deploy:
     runs-on: ubuntu-latest
-    needs: [build-and-test]
-    if: always() && needs.build-and-test.result == 'success'
+    needs: [setup, test]
+    if: always() && needs.test.result == 'success' && github.ref == 'refs/heads/master' && !inputs.dry-run
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target
 target/*
 *.DS_Store
 /cache
+test-output/

--- a/source/java/src/org/lucee/extension/form/tag/jakarta/Form.java
+++ b/source/java/src/org/lucee/extension/form/tag/jakarta/Form.java
@@ -25,12 +25,13 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import jakarta.servlet.http.HttpServletRequest;
 import lucee.loader.util.Util;
 import lucee.runtime.exp.PageException;
 import lucee.runtime.ext.function.BIF;
 import lucee.runtime.type.Collection.Key;
 import lucee.runtime.type.Struct;
+import jakarta.servlet.http.HttpServletRequest;
+
 import lucee.runtime.util.Cast;
 
 /**

--- a/source/java/src/org/lucee/extension/form/tag/javax/Form.java
+++ b/source/java/src/org/lucee/extension/form/tag/javax/Form.java
@@ -31,6 +31,7 @@ import lucee.runtime.ext.function.BIF;
 import lucee.runtime.type.Collection.Key;
 import lucee.runtime.type.Struct;
 import lucee.runtime.util.Cast;
+import lucee.runtime.util.ClassUtil;
 
 /**
  * implementation of the form tag
@@ -417,15 +418,17 @@ public final class Form extends BodyTagImpl {
 	}
 
 	private int _doStartTag() throws PageException, IOException {
-		String contextPath = pageContext.getHttpServletRequest().getContextPath();
+		ClassUtil classUtil = engine.getClassUtil();
+		Cast cast = engine.getCastUtil();
+		Object req = classUtil.callMethod(pageContext, cast.toKey("getHttpServletRequest"), new Object[] {});
+		String contextPath = (String) classUtil.callMethod(req, cast.toKey("getContextPath"), new Object[] {});
 		if (contextPath == null) contextPath = "";
 		if (archive == null) {
 			archive = contextPath + DEFAULT_ARCHIVE;
 		}
 
-		Cast cast = engine.getCastUtil();
 		try {
-			BIF bif = engine.getClassUtil().loadBIF(pageContext, "lucee.runtime.functions.other.CreateUniqueId");
+			BIF bif = classUtil.loadBIF(pageContext, "lucee.runtime.functions.other.CreateUniqueId");
 			count = cast.toString(bif.invoke(pageContext, new Object[] {}));
 		}
 		catch (Exception e) {
@@ -437,7 +440,7 @@ public final class Form extends BodyTagImpl {
 		}
 		attributes.setEL("name", name);
 
-		if (action == null) action = self(pageContext);
+		if (action == null) action = self(classUtil, cast, pageContext);
 		attributes.setEL("action", action);
 
 		String suffix = Util.isEmpty(name) ? "" + count : engine.getCastUtil().toVariableName(name);
@@ -498,18 +501,13 @@ public final class Form extends BodyTagImpl {
 		return EVAL_BODY_INCLUDE;
 	}
 
-	private static String self(Object pageContext) {
-		try {
-			Object req = pageContext.getClass().getMethod("getHttpServletRequest").invoke(pageContext);
-			String servletPath = (String) req.getClass().getMethod("getServletPath").invoke(req);
-			String qs = (String) req.getClass().getMethod("getQueryString").invoke(req);
-			StringBuffer sb = new StringBuffer(servletPath);
-			if (!Util.isEmpty(qs)) sb.append('?').append(qs);
-			return sb.toString();
-		}
-		catch (Exception e) {
-			throw new RuntimeException("Failed to access servlet request via reflection", e);
-		}
+	private static String self(ClassUtil classUtil, Cast cast, Object pageContext) throws PageException {
+		Object req = classUtil.callMethod(pageContext, cast.toKey("getHttpServletRequest"), new Object[] {});
+		String servletPath = (String) classUtil.callMethod(req, cast.toKey("getServletPath"), new Object[] {});
+		String qs = (String) classUtil.callMethod(req, cast.toKey("getQueryString"), new Object[] {});
+		StringBuffer sb = new StringBuffer(servletPath);
+		if (!Util.isEmpty(qs)) sb.append('?').append(qs);
+		return sb.toString();
 	}
 
 	@Override

--- a/tests/LDEV6158.cfc
+++ b/tests/LDEV6158.cfc
@@ -1,0 +1,22 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="form" {
+
+	function run( testResults, testBox ) {
+		describe( "LDEV-6158 cfform jakarta/javax compat", function() {
+
+			it( title="cfform should not throw jakarta error on Lucee 6", body=function() {
+				local.result = _internalRequest(
+					template: "#createURI( 'LDEV6158' )#/LDEV6158.cfm"
+				);
+				expect( result.filecontent.trim() ).toInclude( "<form " );
+			});
+
+		});
+	}
+
+	private string function createURI( string calledName, boolean contract=true ) {
+		var base = getDirectoryFromPath( getCurrentTemplatePath() );
+		var baseURI = contract ? contractPath( base ) : "/test/#listLast( base, '\/' )#";
+		return baseURI & "/" & calledName;
+	}
+
+}

--- a/tests/LDEV6158/LDEV6158.cfm
+++ b/tests/LDEV6158/LDEV6158.cfm
@@ -1,0 +1,3 @@
+<cfform name="testForm" action="/test">
+	<cfinput type="text" name="testField" value="hello">
+</cfform>


### PR DESCRIPTION
## Summary

- javax `Form.java` calls `pageContext.getHttpServletRequest()` which compiles against the jakarta servlet API (Lucee 7 loader in `source/java/libs/`), causing `NoSuchMethodError` on Lucee 6
- Fix: use `engine.getClassUtil().callMethod()` reflection in `javax/Form.java` for `getHttpServletRequest()`, `getContextPath()`, `getServletPath()`, and `getQueryString()`
- Jakarta `Form.java` left unchanged — direct typed calls are fine for Lucee 7
- CI updated: build once, test against Lucee 6.2 + 7.0 (snapshot + stable), Java 11 + 21, deploy gated to master

https://luceeserver.atlassian.net/browse/LDEV-6158

## Test plan

- [x] `LDEV6158.cfc` — `<cfform>` via `_internalRequest` confirms fix on Lucee 6
- [ ] CI green on all matrix combinations (6.2/7.0 × Java 11/21)